### PR TITLE
Switch to ChatCompletion API

### DIFF
--- a/gpt_client.py
+++ b/gpt_client.py
@@ -2,14 +2,24 @@ import os
 import openai
 from dotenv import load_dotenv
 
-load_dotenv() # Loads variables from your .env file
+load_dotenv()  # Loads variables from your .env file
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
-def call_gpt(prompt: str) -> str:
-    response = openai.Completion.create(
-        engine="text-davinci-003",
-        prompt=prompt,
-        max_tokens=300,
+
+def call_gpt(
+    prompt: str,
+    model: str = "gpt-3.5-turbo",
+    max_tokens: int = 300,
+    temperature: float = 0.7,
+) -> str:
+    """Send a prompt to the OpenAI Chat API and return the response text."""
+
+    response = openai.ChatCompletion.create(
+        model=model,
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=max_tokens,
+        temperature=temperature,
     )
-    return response.choices[0].text.strip()
+    # ChatCompletion responses include the assistant message under 'message'
+    return response.choices[0].message["content"].strip()


### PR DESCRIPTION
## Summary
- switch GPT helper to `openai.ChatCompletion.create`
- expose `model`, `max_tokens` and `temperature` options

## Testing
- `python3 -m py_compile gpt_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687f5b050950832bad858a58aea236dc